### PR TITLE
ci: configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+  - package-ecosystem: 'pip'
+    directory: '/dblp-fetcher'
+    schedule:
+      interval: 'monthly'


### PR DESCRIPTION
Automatically keep these dependencies updates:
* GitHub actions
* Python (via poetry)