### PR TITLE
feat: improve detection of arXiv preprints

### DIFF
--- a/dblp-fetcher/dblp_fetcher/main.py
+++ b/dblp-fetcher/dblp_fetcher/main.py
@@ -85,7 +85,7 @@ def _is_unwanted(publication: Publication, blacklist: TitleBlacklist) -> bool:
 
 
 def _is_arxiv_preprint(publication: Publication) -> bool:
-    archive = publication.archiveprefix
+    archive = publication.eprinttype
     return archive is not None and archive.lower() == "arxiv"
 
 

--- a/dblp-fetcher/dblp_fetcher/main.py
+++ b/dblp-fetcher/dblp_fetcher/main.py
@@ -85,8 +85,8 @@ def _is_unwanted(publication: Publication, blacklist: TitleBlacklist) -> bool:
 
 
 def _is_arxiv_preprint(publication: Publication) -> bool:
-    archive = publication.eprinttype
-    return archive is not None and archive.lower() == "arxiv"
+    eprinttype = publication.eprinttype
+    return eprinttype is not None and eprinttype.lower() == "arxiv"
 
 
 def _read_blacklist() -> TitleBlacklist:

--- a/dblp-fetcher/dblp_fetcher/persons/_fetch_sda_associates.py
+++ b/dblp-fetcher/dblp_fetcher/persons/_fetch_sda_associates.py
@@ -1,6 +1,6 @@
 import logging
 
-from dblp_fetcher.persons.model._person import Person
+from dblp_fetcher.persons.model import Person
 from dblp_fetcher.util import url_from_string, year_from_string, fetch_data_from_google_sheets, fetch_google_credentials
 
 

--- a/dblp-fetcher/dblp_fetcher/publications/model/_publications.py
+++ b/dblp-fetcher/dblp_fetcher/publications/model/_publications.py
@@ -118,12 +118,12 @@ class Publication:
             del self.bibtex_dict["keyword"]
 
     @property
-    def archiveprefix(self) -> Optional[str]:
-        return self.bibtex_dict.get("archiveprefix")
-
-    @property
     def author(self) -> Optional[str]:
         return self.bibtex_dict.get("author")
+
+    @property
+    def eprinttype(self) -> Optional[str]:
+        return self.bibtex_dict.get("eprinttype")
 
     @property
     def id(self) -> Optional[str]:

--- a/dblp-fetcher/tests/publications/test_publication.py
+++ b/dblp-fetcher/tests/publications/test_publication.py
@@ -10,7 +10,7 @@ def complete_publication() -> Publication:
         "title": "A 'title' - with_special - characters 2020",
         "year": "2020",
         "keyword": "keyword3 keyword1, keyword2",
-        "archiveprefix": "arxiv",
+        "eprinttype": "arxiv",
     })
 
 
@@ -23,20 +23,20 @@ def test_init_normalizes_keywords(complete_publication: Publication):
     assert complete_publication.bibtex_dict["keywords"] == "keyword1, keyword2, keyword3"
 
 
-def test_archiveprefix_complete(complete_publication: Publication):
-    assert complete_publication.archiveprefix == "arxiv"
-
-
-def test_archiveprefix_empty(empty_publication: Publication):
-    assert empty_publication.archiveprefix is None
-
-
 def test_author_complete(complete_publication: Publication):
     assert complete_publication.author == "John Doe"
 
 
 def test_author_empty(empty_publication: Publication):
     assert empty_publication.author is None
+
+
+def test_eprinttype_complete(complete_publication: Publication):
+    assert complete_publication.eprinttype == "arxiv"
+
+
+def test_eprinttype_empty(empty_publication: Publication):
+    assert empty_publication.eprinttype is None
 
 
 def test_id_complete(complete_publication: Publication):
@@ -108,4 +108,4 @@ def test_update(complete_publication: Publication):
     assert complete_publication.title == "A better title"
     assert complete_publication.year == 2022
     assert complete_publication.keywords == {"keyword1", "keyword2", "keyword3", "keyword4"}
-    assert complete_publication.archiveprefix == "arxiv"
+    assert complete_publication.eprinttype == "arxiv"


### PR DESCRIPTION
The DBLP data sets the field "eprinttype" to "arXiv" for arXiv preprints.